### PR TITLE
Add A* implementation

### DIFF
--- a/src/algorithms/astar.rs
+++ b/src/algorithms/astar.rs
@@ -506,14 +506,9 @@ mod tests {
             2000,
             max_cost_failure,
         );
-
+        println!("{:?}", search_results);
         assert_eq!(search_results.incomplete(), true);
-        assert_eq!(search_results.cost() >= max_cost_failure, true);
         assert_eq!(search_results.ops() < 2000, true);
-
-        let path = search_results.path();
-
-        assert_eq!(path.len(), 0);
 
         // Success case
         let search_results = shortest_path_generic(

--- a/src/algorithms/astar.rs
+++ b/src/algorithms/astar.rs
@@ -197,12 +197,12 @@ where
 
     // Goal not reachable
     let path_opt = get_path_from_parents(&parents, start, best_reached);
-    return AStarSearchResults {
+    AStarSearchResults {
         ops_used: max_ops - remaining_ops,
         cost: best_reached_f_score,
         incomplete: true,
         path: path_opt.unwrap_or_else(|| Vec::new()),
-    };
+    }
 }
 
 fn get_path_from_parents<T: AStarNode>(

--- a/src/algorithms/astar.rs
+++ b/src/algorithms/astar.rs
@@ -1,0 +1,545 @@
+// https://en.wikipedia.org/wiki/A*_search_algorithm
+
+// Sample code pulled (and modified) from: https://doc.rust-lang.org/nightly/std/collections/binary_heap/index.html#examples
+
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashMap};
+use std::hash::Hash;
+
+use screeps::constants::Direction;
+
+use crate::utils::{Neighbors, RangeHeuristic};
+
+/// A simple trait encapsulating what other traits are needed
+/// for a type to be usable in Dijkstra's Algorithm.
+pub trait AStarNode: Eq + Hash + Copy + Ord + Neighbors + RangeHeuristic {}
+impl<T> AStarNode for T where T: Eq + Hash + Copy + Ord + Neighbors + RangeHeuristic {}
+
+#[derive(Debug)]
+pub struct AStarSearchResults<T>
+where
+    T: AStarNode,
+{
+    ops_used: u32,
+    cost: u32,
+    incomplete: bool,
+    path: Vec<T>,
+}
+
+impl<T: AStarNode> AStarSearchResults<T> {
+    /// The number of expand node operations used
+    pub fn ops(&self) -> u32 {
+        self.ops_used
+    }
+
+    /// The movement cost of the result path
+    pub fn cost(&self) -> u32 {
+        self.cost
+    }
+
+    /// Whether the path contained is incomplete
+    pub fn incomplete(&self) -> bool {
+        self.incomplete
+    }
+
+    /// A shortest path from the start node to the goal node
+    pub fn path(&self) -> &[T] {
+        &self.path
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+struct State<T>
+where
+    T: Ord,
+{
+    /// cost to reach this position (the g_score in A* terminology)
+    g_score: u32,
+    /// f_score is the sum of the known cost to reach this position (the g_score) plus the estimated cost remaining from this position in the best possible case
+    f_score: u32,
+    /// track the direction this entry was opened from, so that we're able to check
+    /// only optimal moves (3 or 5 positions instead of all 8)
+    open_direction: Option<Direction>,
+    position: T,
+}
+
+// The priority queue depends on `Ord`.
+// Explicitly implement the trait so the queue becomes a min-heap
+// instead of a max-heap.
+impl<T> Ord for State<T>
+where
+    T: Ord,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Notice that we flip the ordering on costs.
+        // In case of a tie we compare positions - this step is necessary
+        // to make implementations of `PartialEq` and `Ord` consistent.
+        other
+            .f_score
+            .cmp(&self.f_score)
+            .then_with(|| self.position.cmp(&other.position))
+    }
+}
+
+// `PartialOrd` needs to be implemented as well.
+impl<T> PartialOrd for State<T>
+where
+    T: Ord,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+pub fn shortest_path_generic<T: AStarNode, G>(
+    start: T,
+    goal: T,
+    cost_fn: G,
+    max_ops: u32,
+    max_cost: u32,
+) -> AStarSearchResults<T>
+where
+    G: Fn(T) -> u32,
+{
+    let mut remaining_ops: u32 = max_ops;
+    let initial_open_entry = State {
+        g_score: 0,
+        f_score: start.get_range_heuristic(goal),
+        position: start,
+        open_direction: None,
+    };
+    let mut best_reached = start;
+    let mut best_reached_f_score = u32::MAX;
+
+    let mut parents: HashMap<T, T> = HashMap::new();
+    let mut heap = BinaryHeap::new();
+
+    heap.push(initial_open_entry);
+
+    // Examine the frontier with lower cost nodes first (min-heap)
+    while let Some(State {
+        g_score,
+        position,
+        f_score,
+        open_direction,
+    }) = heap.pop()
+    {
+        // We found the goal state, return the search results
+        if position == goal {
+            let path_opt = get_path_from_parents(&parents, start, position);
+            return AStarSearchResults {
+                ops_used: max_ops - remaining_ops,
+                cost: g_score,
+                incomplete: path_opt.is_none(),
+                path: path_opt.unwrap_or_else(|| Vec::new()),
+            };
+        }
+
+        // if this is the most promising path yet, mark it as the point to use for rebuild
+        // if we have to return incomplete
+        if f_score < best_reached_f_score {
+            best_reached = position;
+            best_reached_f_score = f_score;
+        }
+
+        remaining_ops -= 1;
+
+        // Stop searching if we've run out of remaining ops we're allowed to perform
+        if remaining_ops == 0 {
+            break;
+        }
+
+        // don't evaluate children if we're beyond the maximum cost
+        if g_score >= max_cost {
+            continue;
+        }
+
+        // TODO use open_direction and toss to a function
+        for direction in [
+            Direction::Top,
+            Direction::TopRight,
+            Direction::Right,
+            Direction::BottomRight,
+            Direction::Bottom,
+            Direction::BottomLeft,
+            Direction::Left,
+            Direction::TopLeft,
+        ] {
+            let Some(check_pos) = position.checked_add_direction(direction) else {
+                continue;
+            };
+
+            if parents.insert(position, check_pos).is_some() {
+                let next_tile_cost = cost_fn(check_pos);
+
+                let g_score = g_score.saturating_add(next_tile_cost);
+
+                // u32::MAX is our sentinel value for unpassable (or we've saturated the above add), skip this neighbor
+                if g_score == u32::MAX {
+                    continue;
+                }
+
+                let f_score = g_score + check_pos.get_range_heuristic(goal);
+
+                heap.push(State {
+                    g_score,
+                    f_score,
+                    position: check_pos,
+                    open_direction: Some(direction),
+                });
+            }
+        }
+    }
+
+    // Goal not reachable
+    let path_opt = get_path_from_parents(&parents, start, best_reached);
+    return AStarSearchResults {
+        ops_used: max_ops - remaining_ops,
+        cost: best_reached_f_score,
+        incomplete: path_opt.is_none(),
+        path: path_opt.unwrap_or_else(|| Vec::new()),
+    };
+}
+
+fn get_path_from_parents<T: AStarNode>(
+    parents: &HashMap<T, T>,
+    origin: T,
+    end: T,
+) -> Option<Vec<T>> {
+    let mut path = Vec::new();
+
+    let mut current_pos = end;
+
+    path.push(end);
+
+    while current_pos != origin {
+        let parent = parents.get(&current_pos)?;
+        path.push(*parent);
+        current_pos = *parent;
+    }
+
+    Some(path.into_iter().rev().collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use screeps::constants::Direction;
+    use screeps::local::{Position, RoomCoordinate, RoomXY};
+
+    // Helper Functions
+
+    fn new_position(room_name: &str, x: u8, y: u8) -> Position {
+        Position::new(
+            RoomCoordinate::try_from(x).unwrap(),
+            RoomCoordinate::try_from(y).unwrap(),
+            room_name.parse().unwrap(),
+        )
+    }
+
+    fn all_tiles_are_plains_costs<T>(_node: T) -> u32 {
+        1
+    }
+
+    fn all_tiles_are_swamps_costs<T>(_node: T) -> u32 {
+        5
+    }
+
+    fn room_xy_neighbors(node: RoomXY) -> Vec<RoomXY> {
+        node.neighbors()
+    }
+
+    fn position_neighbors(node: Position) -> Vec<Position> {
+        Direction::iter()
+            .filter_map(|dir| node.checked_add_direction(*dir).ok())
+            .collect()
+    }
+
+    // Testing function where all tiles are reachable except for (10, 12)
+    fn roomxy_unreachable_tile_costs(node: RoomXY) -> u32 {
+        if node.x.u8() == 10 && node.y.u8() == 12 {
+            u32::MAX
+        } else {
+            1
+        }
+    }
+
+    // Testing function where all tiles are reachable except for (10, 12)
+    fn position_unreachable_tile_costs(node: Position) -> u32 {
+        if node.x().u8() == 10 && node.y().u8() == 12 {
+            u32::MAX
+        } else {
+            1
+        }
+    }
+
+    // Test Cases
+
+    #[test]
+    fn simple_linear_path_roomxy() {
+        let start = unsafe { RoomXY::unchecked_new(10, 10) };
+        let goal = unsafe { RoomXY::unchecked_new(10, 12) };
+        let search_results =
+            shortest_path_generic(start, goal, all_tiles_are_plains_costs, 2000, 2000);
+
+        assert_eq!(search_results.incomplete(), false);
+        assert_eq!(search_results.cost(), 2);
+        assert_eq!(search_results.ops() < 2000, true);
+
+        let path = search_results.path();
+
+        assert_eq!(path.len(), 3);
+
+        // All three of these nodes are on a shortest path, so we
+        // can't guarantee that we'll get any specific one of them
+        let middle_node_1 = unsafe { RoomXY::unchecked_new(10, 11) };
+        let middle_node_2 = unsafe { RoomXY::unchecked_new(11, 11) };
+        let middle_node_3 = unsafe { RoomXY::unchecked_new(11, 10) };
+
+        assert_eq!(path.contains(&start), true);
+        assert_eq!(path.contains(&goal), true);
+
+        let contains_a_middle_node = path.contains(&middle_node_1)
+            | path.contains(&middle_node_2)
+            | path.contains(&middle_node_3);
+        assert_eq!(contains_a_middle_node, true);
+    }
+
+    #[test]
+    fn simple_linear_path_position() {
+        let room_name = "E5N6";
+        let start = new_position(room_name, 10, 10);
+        let goal = new_position(room_name, 10, 12);
+        let search_results =
+            shortest_path_generic(start, goal, all_tiles_are_plains_costs, 2000, 2000);
+
+        assert_eq!(search_results.incomplete(), false);
+        assert_eq!(search_results.cost(), 2);
+        assert_eq!(search_results.ops() < 2000, true);
+
+        let path = search_results.path();
+
+        assert_eq!(path.len(), 3);
+
+        // All three of these nodes are on a shortest path, so we
+        // can't guarantee that we'll get any specific one of them
+        let middle_node_1 = new_position(room_name, 10, 11);
+        let middle_node_2 = new_position(room_name, 11, 11);
+        let middle_node_3 = new_position(room_name, 11, 10);
+
+        assert_eq!(path.contains(&start), true);
+        assert_eq!(path.contains(&goal), true);
+
+        let contains_a_middle_node = path.contains(&middle_node_1)
+            | path.contains(&middle_node_2)
+            | path.contains(&middle_node_3);
+        assert_eq!(contains_a_middle_node, true);
+    }
+
+    #[test]
+    fn unreachable_target_roomxy() {
+        let start = unsafe { RoomXY::unchecked_new(10, 10) };
+        let goal = unsafe { RoomXY::unchecked_new(10, 12) };
+        let search_results =
+            shortest_path_generic(start, goal, roomxy_unreachable_tile_costs, 2000, 2000);
+
+        println!("{:?}", search_results);
+
+        assert_eq!(search_results.incomplete(), true);
+        assert_eq!(search_results.cost() > 0, true);
+        assert_eq!(search_results.ops() == 2000, true);
+
+        let path = search_results.path();
+
+        assert_eq!(path.len(), 0);
+    }
+
+    #[test]
+    fn unreachable_target_position() {
+        let room_name = "E5N6";
+        let start = new_position(room_name, 10, 10);
+        let goal = new_position(room_name, 10, 12);
+        let search_results =
+            shortest_path_generic(start, goal, position_unreachable_tile_costs, 2000, 2000);
+
+        println!("{:?}", search_results);
+
+        assert_eq!(search_results.incomplete(), true);
+        assert_eq!(search_results.cost() > 0, true);
+        assert_eq!(search_results.ops() == 2000, true);
+
+        let path = search_results.path();
+
+        assert_eq!(path.len(), 0);
+    }
+
+    #[test]
+    fn max_ops_halt_roomxy() {
+        let max_ops_failure = 5;
+        let max_ops_success = 100;
+        let start = unsafe { RoomXY::unchecked_new(10, 10) };
+        let goal = unsafe { RoomXY::unchecked_new(10, 12) }; // This target generally takes ~11 ops to find
+
+        // Failure case
+        let search_results = shortest_path_generic(
+            start,
+            goal,
+            all_tiles_are_plains_costs,
+            max_ops_failure,
+            2000,
+        );
+
+        assert_eq!(search_results.incomplete(), true);
+        assert_eq!(search_results.cost() > 0, true);
+        assert_eq!(search_results.ops() == max_ops_failure, true);
+
+        let path = search_results.path();
+
+        assert_eq!(path.len(), 0);
+
+        // Success case
+        let search_results = shortest_path_generic(
+            start,
+            goal,
+            all_tiles_are_plains_costs,
+            max_ops_success,
+            2000,
+        );
+
+        assert_eq!(search_results.incomplete(), false);
+        assert_eq!(search_results.cost() > 0, true);
+        assert_eq!(search_results.ops() < max_ops_success, true);
+
+        let path = search_results.path();
+
+        assert_eq!(path.len(), 3);
+    }
+
+    #[test]
+    fn max_ops_halt_position() {
+        let max_ops_failure = 5;
+        let max_ops_success = 100;
+        let room_name = "E5N6";
+        let start = new_position(room_name, 10, 10);
+        let goal = new_position(room_name, 10, 12); // This target generally takes ~11 ops to find
+
+        // Failure case
+        let search_results = shortest_path_generic(
+            start,
+            goal,
+            all_tiles_are_plains_costs,
+            max_ops_failure,
+            2000,
+        );
+
+        assert_eq!(search_results.incomplete(), true);
+        assert_eq!(search_results.cost() > 0, true);
+        assert_eq!(search_results.ops() == max_ops_failure, true);
+
+        let path = search_results.path();
+
+        assert_eq!(path.len(), 0);
+
+        // Success case
+        let search_results = shortest_path_generic(
+            start,
+            goal,
+            all_tiles_are_plains_costs,
+            max_ops_success,
+            2000,
+        );
+
+        assert_eq!(search_results.incomplete(), false);
+        assert_eq!(search_results.cost() > 0, true);
+        assert_eq!(search_results.ops() < max_ops_success, true);
+
+        let path = search_results.path();
+
+        assert_eq!(path.len(), 3);
+    }
+
+    #[test]
+    fn max_cost_halt_roomxy() {
+        let max_cost_failure = 5;
+        let max_cost_success = 100;
+        let start = unsafe { RoomXY::unchecked_new(10, 10) };
+        let goal = unsafe { RoomXY::unchecked_new(10, 12) }; // This target will cost 10 to move to
+
+        // Failure case
+        let search_results = shortest_path_generic(
+            start,
+            goal,
+            all_tiles_are_swamps_costs,
+            2000,
+            max_cost_failure,
+        );
+
+        assert_eq!(search_results.incomplete(), true);
+        assert_eq!(search_results.cost() >= max_cost_failure, true);
+        assert_eq!(search_results.ops() < 2000, true);
+
+        let path = search_results.path();
+
+        assert_eq!(path.len(), 0);
+
+        // Success case
+        let search_results = shortest_path_generic(
+            start,
+            goal,
+            all_tiles_are_swamps_costs,
+            2000,
+            max_cost_success,
+        );
+
+        assert_eq!(search_results.incomplete(), false);
+        assert_eq!(search_results.cost() < max_cost_success, true);
+        assert_eq!(search_results.ops() < 2000, true);
+
+        let path = search_results.path();
+
+        assert_eq!(path.len(), 3);
+    }
+
+    #[test]
+    fn max_cost_halt_position() {
+        let max_cost_failure = 5;
+        let max_cost_success = 100;
+        let room_name = "E5N6";
+        let start = new_position(room_name, 10, 10);
+        let goal = new_position(room_name, 10, 12); // This target will cost 10 to move to
+
+        // Failure case
+        let search_results = shortest_path_generic(
+            start,
+            goal,
+            all_tiles_are_swamps_costs,
+            2000,
+            max_cost_failure,
+        );
+
+        assert_eq!(search_results.incomplete(), true);
+        assert_eq!(search_results.cost() >= max_cost_failure, true);
+        assert_eq!(search_results.ops() < 2000, true);
+
+        let path = search_results.path();
+
+        assert_eq!(path.len(), 0);
+
+        // Success case
+        let search_results = shortest_path_generic(
+            start,
+            goal,
+            all_tiles_are_swamps_costs,
+            2000,
+            max_cost_success,
+        );
+
+        assert_eq!(search_results.incomplete(), false);
+        assert_eq!(search_results.cost() < max_cost_success, true);
+        assert_eq!(search_results.ops() < 2000, true);
+
+        let path = search_results.path();
+
+        assert_eq!(path.len(), 3);
+    }
+}

--- a/src/algorithms/astar.rs
+++ b/src/algorithms/astar.rs
@@ -197,7 +197,14 @@ where
         }
 
         let directions: &[Direction] = if let Some(open_direction) = open_direction {
+            // we know what direction this tile was opened from; only explore the tiles
+            // that might potentially be optimal moves
             if open_direction.is_diagonal() {
+                // diagonal move; 2 rotations away might be optimal, while other moves would always
+                // be more efficiently reached without traversing this tile:
+                // ↖↑↗
+                // ←●
+                // ↙ ↖
                 &[
                     open_direction,
                     open_direction.multi_rot(1),
@@ -206,6 +213,12 @@ where
                     open_direction.multi_rot(-2),
                 ]
             } else {
+                // orthogonal move; only continuing straight or turning 45 degrees can be optimal
+                // and should be explored; 90 degree moves would be more efficient as diagonal
+                // moves from the parent tile without traversing this tile:
+                //   ↗
+                // →●→
+                //   ↘
                 &[
                     open_direction,
                     open_direction.multi_rot(1),
@@ -213,7 +226,7 @@ where
                 ]
             }
         } else {
-            // didn't start with a direction, iterate all
+            // didn't start with a direction, this is probably the start tile; check all directions
             // todo can we get this from enum_iterator or something better than this?
             &[
                 Direction::Top,
@@ -271,7 +284,7 @@ fn get_path_from_parents<T: AStarNode>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     use screeps::local::{Position, RoomCoordinate, RoomXY};
 
     // Helper Functions

--- a/src/algorithms/astar.rs
+++ b/src/algorithms/astar.rs
@@ -3,7 +3,10 @@
 // Sample code pulled (and modified) from: https://doc.rust-lang.org/nightly/std/collections/binary_heap/index.html#examples
 
 use std::cmp::Ordering;
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::{
+    hash_map::Entry,
+    {BinaryHeap, HashMap},
+};
 use std::hash::Hash;
 
 use screeps::constants::Direction;
@@ -169,7 +172,8 @@ where
                 continue;
             };
 
-            if parents.insert(check_pos, position).is_none() {
+            if let Entry::Vacant(v) = parents.entry(check_pos) {
+                v.insert(position);
                 let next_tile_cost = cost_fn(check_pos);
 
                 let g_score = g_score.saturating_add(next_tile_cost);

--- a/src/algorithms/astar.rs
+++ b/src/algorithms/astar.rs
@@ -342,10 +342,6 @@ mod tests {
         assert_eq!(search_results.incomplete(), true);
         assert_eq!(search_results.cost() > 0, true);
         assert_eq!(search_results.ops() == 2000, true);
-
-        let path = search_results.path();
-
-        assert_eq!(path.len(), 0);
     }
 
     #[test]
@@ -361,10 +357,6 @@ mod tests {
         assert_eq!(search_results.incomplete(), true);
         assert_eq!(search_results.cost() > 0, true);
         assert_eq!(search_results.ops() > 0, true);
-
-        let path = search_results.path();
-
-        assert_eq!(path.len(), 0);
     }
 
     #[test]
@@ -372,7 +364,7 @@ mod tests {
         let max_ops_failure = 5;
         let max_ops_success = 100;
         let start = unsafe { RoomXY::unchecked_new(10, 10) };
-        let goal = unsafe { RoomXY::unchecked_new(10, 12) }; // This target generally takes ~11 ops to find
+        let goal = unsafe { RoomXY::unchecked_new(30, 30) }; // This target generally takes ~20 ops to find
 
         // Failure case
         let search_results = shortest_path_generic(
@@ -386,10 +378,6 @@ mod tests {
         assert_eq!(search_results.incomplete(), true);
         assert_eq!(search_results.cost() > 0, true);
         assert_eq!(search_results.ops() == max_ops_failure, true);
-
-        let path = search_results.path();
-
-        assert_eq!(path.len(), 0);
 
         // Success case
         let search_results = shortest_path_generic(
@@ -406,7 +394,7 @@ mod tests {
 
         let path = search_results.path();
 
-        assert_eq!(path.len(), 3);
+        assert_eq!(path.len(), 21);
     }
 
     #[test]
@@ -415,7 +403,7 @@ mod tests {
         let max_ops_success = 100;
         let room_name = "E5N6";
         let start = new_position(room_name, 10, 10);
-        let goal = new_position(room_name, 10, 12); // This target generally takes ~11 ops to find
+        let goal = new_position(room_name, 30, 30); // This target generally takes ~20 ops to find
 
         // Failure case
         let search_results = shortest_path_generic(
@@ -429,10 +417,6 @@ mod tests {
         assert_eq!(search_results.incomplete(), true);
         assert_eq!(search_results.cost() > 0, true);
         assert_eq!(search_results.ops() == max_ops_failure, true);
-
-        let path = search_results.path();
-
-        assert_eq!(path.len(), 0);
 
         // Success case
         let search_results = shortest_path_generic(
@@ -449,7 +433,7 @@ mod tests {
 
         let path = search_results.path();
 
-        assert_eq!(path.len(), 3);
+        assert_eq!(path.len(), 21);
     }
 
     #[test]
@@ -469,12 +453,7 @@ mod tests {
         );
 
         assert_eq!(search_results.incomplete(), true);
-        assert_eq!(search_results.cost() >= max_cost_failure, true);
         assert_eq!(search_results.ops() < 2000, true);
-
-        let path = search_results.path();
-
-        assert_eq!(path.len(), 0);
 
         // Success case
         let search_results = shortest_path_generic(

--- a/src/algorithms/astar.rs
+++ b/src/algorithms/astar.rs
@@ -196,10 +196,25 @@ where
             continue;
         }
 
-        check_directions(
-            position,
-            goal,
-            g_score,
+        let directions: &[Direction] = if let Some(open_direction) = open_direction {
+            if open_direction.is_diagonal() {
+                &[
+                    open_direction,
+                    open_direction.multi_rot(1),
+                    open_direction.multi_rot(-1),
+                    open_direction.multi_rot(2),
+                    open_direction.multi_rot(-2),
+                ]
+            } else {
+                &[
+                    open_direction,
+                    open_direction.multi_rot(1),
+                    open_direction.multi_rot(-1),
+                ]
+            }
+        } else {
+            // didn't start with a direction, iterate all
+            // todo can we get this from enum_iterator or something better than this?
             &[
                 Direction::Top,
                 Direction::TopRight,
@@ -209,7 +224,14 @@ where
                 Direction::BottomLeft,
                 Direction::Left,
                 Direction::TopLeft,
-            ],
+            ]
+        };
+
+        check_directions(
+            position,
+            goal,
+            g_score,
+            directions,
             &cost_fn,
             &mut heap,
             &mut parents,
@@ -249,7 +271,7 @@ fn get_path_from_parents<T: AStarNode>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use screeps::constants::Direction;
+    
     use screeps::local::{Position, RoomCoordinate, RoomXY};
 
     // Helper Functions

--- a/src/algorithms/dijkstra.rs
+++ b/src/algorithms/dijkstra.rs
@@ -263,7 +263,7 @@ fn get_path_from_parents<T: DijkstraNode>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     use screeps::local::{Position, RoomCoordinate, RoomXY};
 
     // Helper Functions

--- a/src/algorithms/dijkstra.rs
+++ b/src/algorithms/dijkstra.rs
@@ -263,7 +263,7 @@ fn get_path_from_parents<T: DijkstraNode>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use screeps::constants::Direction;
+    
     use screeps::local::{Position, RoomCoordinate, RoomXY};
 
     // Helper Functions

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -1,1 +1,2 @@
+pub mod astar;
 pub mod dijkstra;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -20,14 +20,32 @@ pub fn get_movement_cost_lcm_from_terrain(
     cm
 }
 
-pub fn room_xy_neighbors(node: RoomXY) -> Vec<RoomXY> {
-    node.neighbors()
+pub trait Neighbors {
+    fn checked_add_direction(self, direction: Direction) -> Option<Self>
+    where
+        Self: Sized + Copy;
+
+    fn neighbors(self) -> Vec<Self>
+    where
+        Self: Sized + Copy,
+    {
+        Direction::iter()
+            .copied()
+            .filter_map(|dir| self.checked_add_direction(dir))
+            .collect()
+    }
 }
 
-pub fn position_neighbors(node: Position) -> Vec<Position> {
-    Direction::iter()
-        .filter_map(|dir| node.checked_add_direction(*dir).ok())
-        .collect()
+impl Neighbors for RoomXY {
+    fn checked_add_direction(self, direction: Direction) -> Option<Self> {
+        Self::checked_add_direction(self, direction)
+    }
+}
+
+impl Neighbors for Position {
+    fn checked_add_direction(self, direction: Direction) -> Option<Self> {
+        Self::checked_add_direction(self, direction).ok()
+    }
 }
 
 /// Builds a cost function closure that pulls costs from a `LocalCostMatrix`.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -48,6 +48,22 @@ impl Neighbors for Position {
     }
 }
 
+pub trait RangeHeuristic {
+    fn get_range_heuristic(self, other: Self) -> u32;
+}
+
+impl RangeHeuristic for RoomXY {
+    fn get_range_heuristic(self, other: Self) -> u32 {
+        self.get_range_to(other)
+    }
+}
+
+impl RangeHeuristic for Position {
+    fn get_range_heuristic(self, other: Self) -> u32 {
+        self.get_range_to(other)
+    }
+}
+
 /// Builds a cost function closure that pulls costs from a `LocalCostMatrix`.
 ///
 /// # Example


### PR DESCRIPTION
Added A* implementation. Because it needed access to a checked direction interface as well as neighbors, added `Neighbors` trait (with overridable neighbors implementation so we can use something like `describeExits` on a neighbors impl for `RoomName`, for instance).

Also added `RangeHeuristic` trait for those algos that need it (A* does, while Dijkstra's does not) - though maybe there's not a lot of reason for these traits to be separate, or `DijkstraNode` vs `AStarNode`?

Butchered the tests a wee bit to make 'em pass, chopping out path length checks and max ops checks in cases where I'd made the A* search return an intermediate but incomplete result - not super attached to this design in any way (would be fine with an empty path as the other implementation does).